### PR TITLE
Fix range channel comments typo

### DIFF
--- a/go/statements.cc
+++ b/go/statements.cc
@@ -6011,11 +6011,11 @@ For_range_statement::lower_range_channel(Gogo*,
 
   // The loop we generate:
   //   for {
-  //           index_temp, ok_temp = <-range
+  //           value_temp, ok_temp = <-range
   //           if !ok_temp {
   //                   break
   //           }
-  //           index = index_temp
+  //           value = value_temp
   //           original body
   //   }
 


### PR DESCRIPTION
In for-range statement, if the range expression is a channel, at most one iteration variable is permitted. The variable should be element not
index.