### PR TITLE
Fix awk substr invocation in libgo buildsyste

### DIFF
--- a/libgo/mklinknames.awk
+++ b/libgo/mklinknames.awk
@@ -37,7 +37,7 @@ BEGIN {
     # The goal is to extract "__timegm50".
     if ((def | getline fndef) > 0 && match(fndef, "__asm__\\(\"\\*?")) {
 	asmname = substr(fndef, RSTART + RLENGTH)
-	asmname = substr(asmname, 0, length(asmname) - 2)
+	asmname = substr(asmname, 1, length(asmname) - 2)
 	printf("//go:linkname %s %s\n", gofnname, asmname)
     } else {
 	# Assume the asm name is the same as the declared C name.


### PR DESCRIPTION
The awk script used a zero-based index which worked on surprisingly
many plattforms. According to the man page, however, the function
expects one-based indexing.

For reference see this bug in the go git repository:

https://github.com/golang/go/issues/45843

Signed-off-by: Christoph Höger <choeger@umpa-net.de>