### PR TITLE
Fix unnamed bool convert

### DIFF
--- a/go/runtime.cc
+++ b/go/runtime.cc
@@ -104,7 +104,7 @@ runtime_function_type(Runtime_function_type bft)
 	  go_unreachable();
 
 	case RFT_BOOL:
-	  t = Type::make_boolean_type();
+	  t = Type::lookup_bool_type();
 	  break;
 
 	case RFT_BOOLPTR:


### PR DESCRIPTION
There is a fix for converting unnamed bool to empty interface error.

For reference see this bug in the go git repository:
https://github.com/golang/go/issues/52535