### PR TITLE
Build gofrontend as a standalone library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 last-change
 .clang-format
+bazel-*

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,9 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "go_frontend",
+    srcs =  glob(["go/*.cc", "ir/*.cc"]),
+    hdrs = glob(["go/*.h", "ir/*.h"]),
+    visibility = ["//visibility:public"],
+    deps = ["@gmp//:gmp_", "@mpfr//:mpfr_external"]
+)

--- a/BUILD
+++ b/BUILD
@@ -3,8 +3,8 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 cc_library(
     name = "go_frontend",
     srcs = glob(["go/*.cc", "ir/*.cc"]),
-    hdrs = glob(["go/*.h", "ir/*.h"]),
-    copts = ["-Iir"],
+    hdrs = glob(["go/*.h", "go/runtime.def", "ir/*.h"]),
+    copts = ["-std=c++17 -Iir"],
     visibility = ["//visibility:public"],
     deps = ["@gmp//:gmp_", "@mpfr//:mpfr_external", "@mpc//:mpc_"]
 )

--- a/BUILD
+++ b/BUILD
@@ -2,8 +2,9 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
     name = "go_frontend",
-    srcs =  glob(["go/*.cc", "ir/*.cc"]),
+    srcs = glob(["go/*.cc", "ir/*.cc"]),
     hdrs = glob(["go/*.h", "ir/*.h"]),
+    copts = ["-Iir"],
     visibility = ["//visibility:public"],
-    deps = ["@gmp//:gmp_", "@mpfr//:mpfr_external"]
+    deps = ["@gmp//:gmp_", "@mpfr//:mpfr_external", "@mpc//:mpc_"]
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -71,6 +71,15 @@ maybe(
 )
 
 maybe(
+    http_archive,
+    name = "mpc",
+    build_file = "//:bazel/mpc.BUILD",
+    sha256 = "e90f2d99553a9c19911abdb4305bf8217106a957e3994436428572c8dfe8fda6",
+    strip_prefix = "mpc-1.2.0",
+    urls = ["https://ftp.gnu.org/gnu/mpc/mpc-1.2.0.tar.gz", "https://mirrors.kernel.org/gnu/mpc/mpc-1.2.0.tar.gz"],
+)
+
+maybe(
     new_git_repository,
     name = "pfm",
     build_file = "//:bazel/pfm.BUILD",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,90 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
+
+SKYLIB_VERSION = "1.3.0"
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/{version}/bazel-skylib-{version}.tar.gz".format(version=SKYLIB_VERSION),
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/{version}/bazel-skylib-{version}.tar.gz".format(version=SKYLIB_VERSION),
+    ],
+)
+
+maybe(
+    http_archive,
+    name = "llvm_zlib",
+    build_file = "//:bazel/zlib-ng.BUILD",
+    sha256 = "e36bb346c00472a1f9ff2a0a4643e590a254be6379da7cddd9daeb9a7f296731",
+    strip_prefix = "zlib-ng-2.0.7",
+    urls = [
+        "https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.0.7.zip",
+    ],
+)
+
+# llvm libc math tests rely on `mpfr`.
+# The availability of `mpfr` is controlled by a flag and can be either `disable`, `system` or `external`.
+# Continuous integration uses `system` to speed up the build process (see .bazelrc).
+# Otherwise by default it is set to `external`: `mpfr` and `gmp` are built from source by using `rules_foreign_cc`.
+# Note: that building from source requires `m4` to be installed on the host machine.
+# This is a known issue: https://github.com/bazelbuild/rules_foreign_cc/issues/755.
+
+git_repository(
+    name = "rules_foreign_cc",
+    remote = "https://github.com/bazelbuild/rules_foreign_cc.git",
+    tag = "0.9.0",
+)
+
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
+
+rules_foreign_cc_dependencies()
+
+maybe(
+    http_archive,
+    name = "gmp",
+    build_file = "//:bazel/gmp.BUILD",
+    sha256 = "fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2",
+    strip_prefix = "gmp-6.2.1",
+    urls = [
+        "https://gmplib.org/download/gmp/gmp-6.2.1.tar.xz",
+        "https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.xz",
+    ],
+)
+
+# https://www.mpfr.org/mpfr-current/
+#
+# When updating to a newer version, don't use URLs with "mpfr-current" in them.
+# Instead, find a stable URL like the one used currently.
+maybe(
+    http_archive,
+    name = "mpfr",
+    build_file = "//:bazel/mpfr.BUILD",
+    sha256 = "9cbed5d0af0d9ed5e9f8dd013e17838eb15e1db9a6ae0d371d55d35f93a782a7",
+    strip_prefix = "mpfr-4.1.1",
+    urls = ["https://www.mpfr.org/mpfr-4.1.1/mpfr-4.1.1.tar.gz"],
+)
+
+maybe(
+    new_git_repository,
+    name = "pfm",
+    build_file = "//:bazel/pfm.BUILD",
+    remote = "https://git.code.sf.net/p/perfmon2/libpfm4",
+    tag = "v4.12.1",
+)
+
+maybe(
+    http_archive,
+    name = "llvm_zstd",
+    build_file = "//:bazel/zstd.BUILD",
+    sha256 = "7c42d56fac126929a6a85dbc73ff1db2411d04f104fae9bdea51305663a83fd0",
+    strip_prefix = "zstd-1.5.2",
+    urls = [
+        "https://github.com/facebook/zstd/releases/download/v1.5.2/zstd-1.5.2.tar.gz"
+    ],
+)

--- a/bazel/gmp.BUILD
+++ b/bazel/gmp.BUILD
@@ -1,0 +1,20 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make_variant")
+
+filegroup(
+    name = "sources",
+    srcs = glob(["**"]),
+)
+
+configure_make_variant(
+    name = "gmp",
+    configure_options = ["--with-pic"],
+    copts = ["-w"],
+    lib_name = "libgmp",
+    lib_source = ":sources",
+    toolchain = "@rules_foreign_cc//toolchains:preinstalled_autoconf_toolchain",
+    visibility = ["//visibility:public"],
+)

--- a/bazel/mpc.BUILD
+++ b/bazel/mpc.BUILD
@@ -1,0 +1,33 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make_variant")
+
+filegroup(
+    name = "sources",
+    srcs = glob(["**"]),
+)
+
+configure_make_variant(
+    name = "mpc",
+    configure_options = ["--with-pic"],
+    copts = ["-w"],
+    lib_name = "libmpc",
+    lib_source = ":sources",
+    toolchain = "@rules_foreign_cc//toolchains:preinstalled_autoconf_toolchain",
+    visibility = ["//visibility:public"],
+    deps = ["@gmp//:gmp_", "@mpfr//:mpfr_"],
+)
+
+alias(
+    name = "mpc_external",
+    actual = "@mpc//:mpc_",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "mpc_system",
+    linkopts = ["-lmpc"],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/mpfr.BUILD
+++ b/bazel/mpfr.BUILD
@@ -1,0 +1,33 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make_variant")
+
+filegroup(
+    name = "sources",
+    srcs = glob(["**"]),
+)
+
+configure_make_variant(
+    name = "mpfr",
+    configure_options = ["--with-pic"],
+    copts = ["-w"],
+    lib_name = "libmpfr",
+    lib_source = ":sources",
+    toolchain = "@rules_foreign_cc//toolchains:preinstalled_autoconf_toolchain",
+    visibility = ["//visibility:public"],
+    deps = ["@gmp//:gmp_"],
+)
+
+alias(
+    name = "mpfr_external",
+    actual = "@mpfr//:mpfr_",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "mpfr_system",
+    linkopts = ["-lmpfr"],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/zlib-ng.BUILD
+++ b/bazel/zlib-ng.BUILD
@@ -1,0 +1,108 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+
+package(
+    default_visibility = ["//visibility:public"],
+    # BSD/MIT-like license (for zlib)
+    licenses = ["notice"],
+)
+
+bool_flag(
+    name = "llvm_enable_zlib",
+    build_setting_default = True,
+)
+
+config_setting(
+    name = "llvm_zlib_enabled",
+    flag_values = {":llvm_enable_zlib": "true"},
+)
+
+genrule(
+    # The input template is identical to the CMake output.
+    name = "zconf_gen",
+    srcs = ["zconf.h.in"],
+    outs = ["zconf.h"],
+    cmd = "cp $(SRCS) $(OUTS)",
+)
+
+cc_library(
+    name = "zlib",
+    srcs = select({
+        ":llvm_zlib_enabled": [
+            "adler32_p.h",
+            "chunkset_tpl.h",
+            "crc32_p.h",
+            "crc32_tbl.h",
+            "crc32_comb_tbl.h",
+            "deflate.h",
+            "deflate_p.h",
+            "functable.h",
+            "fallback_builtins.h",
+            "inffast.h",
+            "inffixed_tbl.h",
+            "inflate.h",
+            "inflate_p.h",
+            "inftrees.h",
+            "insert_string_tpl.h",
+            "match_tpl.h",
+            "trees.h",
+            "trees_emit.h",
+            "trees_tbl.h",
+            "zbuild.h",
+            "zendian.h",
+            "zutil.h",
+            "adler32.c",
+            "chunkset.c",
+            "compare258.c",
+            "compress.c",
+            "crc32.c",
+            "crc32_comb.c",
+            "deflate.c",
+            "deflate_fast.c",
+            "deflate_medium.c",
+            "deflate_quick.c",
+            "deflate_slow.c",
+            "functable.c",
+            "infback.c",
+            "inffast.c",
+            "inflate.c",
+            "inftrees.c",
+            "insert_string.c",
+            "trees.c",
+            "uncompr.c",
+            "zutil_p.h",
+            "zutil.c",
+        ],
+        "//conditions:default": [],
+    }),
+    hdrs = select({
+        ":llvm_zlib_enabled": [
+            "zlib.h",
+            ":zconf_gen",
+        ],
+        "//conditions:default": [],
+    }),
+    copts = [
+        "-std=c11",
+        "-DZLIB_COMPAT",
+        "-DWITH_GZFILEOP",
+        "-DWITH_OPTIM",
+        "-DWITH_NEW_STRATEGIES",
+        # For local builds you might want to add "-DWITH_NATIVE_INSTRUCTIONS"
+        # here to improve performance. Native instructions aren't enabled in
+        # the default config for reproducibility.
+    ],
+    defines = select({
+        ":llvm_zlib_enabled": [
+            "LLVM_ENABLE_ZLIB=1",
+        ],
+        "//conditions:default": [],
+    }),
+    # Clang includes zlib with angled instead of quoted includes, so we need
+    # strip_include_prefix here.
+    strip_include_prefix = ".",
+    visibility = ["//visibility:public"],
+)

--- a/bazel/zstd.BUILD
+++ b/bazel/zstd.BUILD
@@ -1,0 +1,54 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+
+package(
+    default_visibility = ["//visibility:public"],
+    # BSD/MIT-like license (for zstd)
+    licenses = ["notice"],
+)
+
+bool_flag(
+    name = "llvm_enable_zstd",
+    build_setting_default = True,
+)
+
+config_setting(
+    name = "llvm_zstd_enabled",
+    flag_values = {":llvm_enable_zstd": "true"},
+)
+
+cc_library(
+    name = "zstd",
+    srcs = select({
+        ":llvm_zstd_enabled": glob([
+            "lib/common/*.c",
+            "lib/common/*.h",
+            "lib/compress/*.c",
+            "lib/compress/*.h",
+            "lib/decompress/*.c",
+            "lib/decompress/*.h",
+            "lib/decompress/*.S",
+            "lib/dictBuilder/*.c",
+            "lib/dictBuilder/*.h",
+        ]),
+        "//conditions:default": [],
+    }),
+    hdrs = select({
+        ":llvm_zstd_enabled": [
+            "lib/zstd.h",
+            "lib/zdict.h",
+            "lib/zstd_errors.h",
+        ],
+        "//conditions:default": [],
+    }),
+    defines = select({
+        ":llvm_zstd_enabled": [
+            "LLVM_ENABLE_ZSTD=1",
+            "ZSTD_MULTITHREAD",
+        ],
+        "//conditions:default": [],
+    }),
+    strip_include_prefix = "lib",
+)

--- a/go/lex.h
+++ b/go/lex.h
@@ -12,6 +12,8 @@
 #include "operator.h"
 #include "go-linemap.h"
 
+#define ATTRIBUTE_UNUSED __attribute__((unused))
+
 struct Unicode_range;
 
 // The keywords.  These must be in sorted order, other than
@@ -561,7 +563,7 @@ class Lex
   gather_embed(const char*, const char*);
 
   // The input file name.
-  const char* input_file_name_; // ATTRIBUTE_UNUSED;
+  const char* input_file_name_ ATTRIBUTE_UNUSED;
   // The input file.
   FILE* input_file_;
   // The object used to keep track of file names and line numbers.

--- a/go/lex.h
+++ b/go/lex.h
@@ -561,7 +561,7 @@ class Lex
   gather_embed(const char*, const char*);
 
   // The input file name.
-  const char* input_file_name_ ATTRIBUTE_UNUSED;
+  const char* input_file_name_; // ATTRIBUTE_UNUSED;
   // The input file.
   FILE* input_file_;
   // The object used to keep track of file names and line numbers.

--- a/ir/filenames.h
+++ b/ir/filenames.h
@@ -1,0 +1,6 @@
+
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This file included by code in gofrontend; currently a stub.

--- a/ir/go-c.h
+++ b/ir/go-c.h
@@ -1,0 +1,60 @@
+//===-- go-c.h ------------------------------------------------------------===//
+//
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+//===----------------------------------------------------------------------===//
+//
+// Header file included by gofrontend; provides definitions for FE routines such
+// as 'go_add_search_path', as well as the struct go_create_gogo_args.
+
+#ifndef LLVMGOFRONTEND_GO_C_H
+#define LLVMGOFRONTEND_GO_C_H
+
+#define GO_EXTERN_C
+
+class Linemap;
+class Backend;
+
+// Struct used to initialize gofrontend. Bridge creates an instance of this
+// struct and passes it to gofrontend as part of setup.
+
+struct go_create_gogo_args
+{
+  int int_type_size;
+  int pointer_size;
+  const char* pkgpath;
+  const char* prefix;
+  const char* relative_import_path;
+  const char* c_header;
+  const char* embedcfg;
+  Backend* backend;
+  Linemap* linemap;
+  bool check_divide_by_zero;
+  bool check_divide_overflow;
+  bool compiling_runtime;
+  int debug_escape_level;
+  const char* debug_escape_hash;
+  int64_t nil_check_size_threshold;
+  bool debug_optimization;
+  bool need_eqtype;
+};
+
+// These are defined in gofrontend and called from the bridge.
+extern bool saw_errors(void);
+extern const char *go_localize_identifier(const char *);
+extern const char *go_read_export_data (int, off_t, char **, size_t *, int *);
+extern int go_enable_dump (const char*);
+extern int go_enable_optimize (const char*, int);
+extern void go_add_search_path(const char *);
+extern void go_create_gogo(const struct go_create_gogo_args *);
+extern void go_parse_input_files(const char **, unsigned int,
+                                 bool only_check_syntax,
+                                 bool require_return_statement);
+extern void go_write_globals(void);
+
+// Defined in the bridge; called by gofrontend.
+extern void go_imported_unsafe(void);
+
+#endif /* !defined(LLVMGOFRONTEND_GO_C_H) */

--- a/ir/go-location.h
+++ b/ir/go-location.h
@@ -1,0 +1,50 @@
+// go-location.h -- GCC specific Location declaration.   -*- C++ -*-
+
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef GO_LOCATION_H
+#define GO_LOCATION_H
+
+#include "go-system.h"
+
+// Opaque tag/handle returned by the linemap
+
+typedef unsigned linemap_handle;
+
+// A location in an input source file.
+
+class Location
+{
+ public:
+  Location()
+      : handle_(0)
+  { }
+
+  explicit Location(linemap_handle handle)
+      : handle_(handle)
+  { }
+
+  linemap_handle
+  handle() const
+  { return this->handle_; }
+
+ private:
+  linemap_handle handle_;
+};
+
+// The Go frontend requires the ability to compare Locations.
+inline bool
+operator<(Location loca, Location locb)
+{
+  return loca.handle() < locb.handle();
+}
+
+inline bool
+operator==(const Location loca, const Location locb)
+{
+  return loca.handle() == locb.handle();
+}
+
+#endif // !defined(GO_LOCATION_H)

--- a/ir/go-system.h
+++ b/ir/go-system.h
@@ -62,8 +62,7 @@ extern void go_assert_fail(const char *expr, const char *filename,
       : go_assert_fail (#expr, __FILE__, __LINE__, __PRETTY_FUNCTION__))
 
 // #include "llvm-includes.h"
-// todo: impl function
-#define go_unreachable() (throw exception("unreachable"))
+#define go_unreachable() (throw std::runtime_error("unreachable"))
 
 #define ARRAY_SIZE(A) (sizeof (A) / sizeof ((A)[0]))
 

--- a/ir/go-system.h
+++ b/ir/go-system.h
@@ -1,0 +1,85 @@
+
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef GO_SYSTEM_H
+#define GO_SYSTEM_H
+
+#include <algorithm>
+#include <string>
+#include <list>
+#include <map>
+#include <set>
+#include <vector>
+#include <sstream>
+#include <climits>
+#include <ctype.h>
+#include <stdarg.h>
+
+# include <unordered_map>
+# include <unordered_set>
+
+#include <filesystem>
+
+# define Unordered_map(KEYTYPE, VALTYPE) \
+	std::unordered_map<KEYTYPE, VALTYPE>
+
+# define Unordered_map_hash(KEYTYPE, VALTYPE, HASHFN, EQFN) \
+	std::unordered_map<KEYTYPE, VALTYPE, HASHFN, EQFN>
+
+# define Unordered_set(KEYTYPE) \
+	std::unordered_set<KEYTYPE>
+
+# define Unordered_set_hash(KEYTYPE, HASHFN, EQFN) \
+	std::unordered_set<KEYTYPE, HASHFN, EQFN>
+
+#include <iostream>
+#include <assert.h>
+#include <string.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#define _(x) x
+
+// In a previous version of this file, go_assert was simply #define'd to
+// 'assert', meaning that gofrontend assertions would be compiled away for
+// release builds, which was problematic. This version of go_assert applies for
+// all build flavors, meaning that we'll get assertion checking for release
+// builds. FWIW turning on assertions for all of LLVM can be very expensive from
+// a compile time perspective, but keeping the assertion checks in gofrontend
+// comes with more modest overhead.
+
+extern void go_assert_fail(const char *expr, const char *filename,
+                           int line, const char *function);
+
+#define go_assert(expr) \
+     (static_cast <bool> (expr)						\
+      ? void (0)							\
+      : go_assert_fail (#expr, __FILE__, __LINE__, __PRETTY_FUNCTION__))
+
+// #include "llvm-includes.h"
+// todo: impl function
+#define go_unreachable() (throw exception("unreachable"))
+
+#define ARRAY_SIZE(A) (sizeof (A) / sizeof ((A)[0]))
+
+#define IS_ABSOLUTE_PATH(x) \
+  std::filesystem::path(x).is_absolute()
+
+#define HOST_BITS_PER_WIDE_INT 64
+#define HOST_WIDE_INT long
+
+#define ISALNUM(x) isalnum(x)
+
+extern const char *lbasename(const char *);
+extern const char *xstrerror(int);
+extern bool IS_DIR_SEPARATOR(char);
+extern bool ISXDIGIT(char);
+
+#define MAX(X,Y) ((X) > (Y) ? (X) : (Y))
+
+#endif // !defined(GO_SYSTEM_H)


### PR DESCRIPTION
This is a follow up of https://github.com/golang/go/issues/60363#issuecomment-1559960214.

As an initial effort, this change-set includes minimal changes to build it as a standalone library.

1. Added bazel build files.
2. Added some required header files.
